### PR TITLE
Check if overrideMimeType is available before using it

### DIFF
--- a/lib/locale_pack/helpers/pack_helper.rb
+++ b/lib/locale_pack/helpers/pack_helper.rb
@@ -9,7 +9,9 @@ module LocalePack
           var localePacks = {};
           function loadTranslationPack(path, async, callback) {
             var xobj = new XMLHttpRequest();
-            xobj.overrideMimeType("application/json");
+            if ( xobj.overrideMimeType ) {
+              xobj.overrideMimeType("application/json");
+            }
             xobj.open('GET', path, async);
             xobj.onreadystatechange = function () {
                   if (xobj.readyState == 4 && xobj.status == "200") {


### PR DESCRIPTION
The 'overrideMimeType' is only available on 'XMLHttpRequest' for IE10 and above. So we will check if its available before using it