### PR TITLE
fix(PackFile): ensure "find_by_name" always evaluates name as string

### DIFF
--- a/lib/locale_pack/models/pack_file.rb
+++ b/lib/locale_pack/models/pack_file.rb
@@ -12,7 +12,7 @@ module LocalePack
       end
 
       def find_by_name(name)
-        find_all.detect { |file_pack| file_pack.name == name} ||
+        find_all.detect { |file_pack| file_pack.name.to_s == name.to_s} ||
             (raise ArgumentError, "Locale Pack with name '#{name}' not found")
       end
     end

--- a/spec/tasks/locale_pack_task_spec.rb
+++ b/spec/tasks/locale_pack_task_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+require 'rake'
+
+describe 'locale_pack.rake' do
+  before do
+    Rake.application.rake_require "locale_pack/tasks/locale_pack"
+    Rake::Task.define_task(:environment)
+  end
+
+  describe 'locale_pack:compile:one[name]' do
+    context 'given a valid "name"' do
+      let(:name) { 'example' }
+
+      around(:example) do |example|
+        example.run
+        pack_file = LocalePack::PackFile.find_by_name(name.to_sym) rescue nil
+        pack_file&.destroy
+        LocalePack.manifest.delete
+      end
+
+      it 'compiles the PackFile with the given name' do
+        expect(LocalePack::PackFile).to receive(:find_by_name).with(name.to_sym).and_call_original
+        expect {
+            Rake::Task["locale_pack:compile:one"].execute(Rake::TaskArguments.new([:name],[name]))
+        }.to_not raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
This fixes the "rake locale_pack:compile:one" command.

Ref: https://github.com/corthmann/locale_pack/issues/5