### PR TITLE
Add closing tag to the script element

### DIFF
--- a/lib/locale_pack/helpers/pack_helper.rb
+++ b/lib/locale_pack/helpers/pack_helper.rb
@@ -5,7 +5,7 @@ module LocalePack
 
     def javascript_locale_pack_tag(name, locale: nil)
       <<-EOS.html_safe
-      <script type='text/javascript' src='#{locale_pack_path(name, locale: locale)}' />
+      <script type='text/javascript' src='#{locale_pack_path(name, locale: locale)}'></script>
       EOS
     end
 


### PR DESCRIPTION
The `<script>` tag is not self-closing by the specification so this makes the browser to ignore everything that follows this tag until it finds a proper `</script>` closing tag.

![Screenshot 2019-08-23 at 13 11 17](https://user-images.githubusercontent.com/777187/63588743-83071300-c5a7-11e9-8f9c-f39371162cb0.png)
