### PR TITLE
feat(LocalePack): read the content of the given locale pack file

### DIFF
--- a/lib/locale_pack/helpers/pack_helper.rb
+++ b/lib/locale_pack/helpers/pack_helper.rb
@@ -30,9 +30,6 @@ module LocalePack
         locale_file_path = File.join(@output_path, pack.file_name)
 
         if !@locale_packs.key?(locale_file_path) && File.exists?(locale_file_path)
-          Rails.logger.info('LocalePack::Reader: reading & caching content for ' + @output_path)
-          Rails.logger.info('LocalePack::Reader: reading & caching content for ' + locale_file_path)
-
           locale_file = File.file?(locale_file_path)
           return '' unless locale_file
           locale_pack_content = File.read(locale_file_path)

--- a/lib/locale_pack/helpers/pack_helper.rb
+++ b/lib/locale_pack/helpers/pack_helper.rb
@@ -9,19 +9,39 @@ module LocalePack
       EOS
     end
 
-    # returns the locale pack's file content
-    def read_locale_pack(name, locale: nil)
-      path = "public#{locale_pack_path(name, locale: locale)}"
-
-      return unless File.file?(path)
-      locale_pack_content = File.read(path)
-
-      raw(locale_pack_content)
-    end
-
     def locale_pack_path(name, locale: nil)
       pack = LocalePack::Pack.find_by_name(name, locale: locale)
       pack.path
+    end
+
+    class Reader
+      include Singleton
+      include LocalePack::PackHelper
+
+      def initialize
+        # memoized packs - the file path is used as the key and the file content as the value
+        @locale_packs = {}
+        @output_path = LocalePack.config&.output_path
+      end
+
+      # returns the locale pack's file content
+      def read_locale_pack(name, locale: nil)
+        pack = LocalePack::Pack.find_by_name(name, locale: locale)
+        locale_file_path = File.join(@output_path, pack.file_name)
+
+        if !@locale_packs.key?(locale_file_path) && File.exists?(locale_file_path)
+          Rails.logger.info('LocalePack::Reader: reading & caching content for ' + @output_path)
+          Rails.logger.info('LocalePack::Reader: reading & caching content for ' + locale_file_path)
+
+          locale_file = File.file?(locale_file_path)
+          return '' unless locale_file
+          locale_pack_content = File.read(locale_file_path)
+
+          @locale_packs[locale_file_path] = locale_pack_content
+        end
+
+        @locale_packs[locale_file_path]
+      end
     end
 
   end

--- a/lib/locale_pack/helpers/pack_helper.rb
+++ b/lib/locale_pack/helpers/pack_helper.rb
@@ -9,6 +9,16 @@ module LocalePack
       EOS
     end
 
+    # returns the locale pack's file content
+    def read_locale_pack(name, locale: nil)
+      path = "public#{locale_pack_path(name, locale: locale)}"
+
+      return unless File.file?(path)
+      locale_pack_content = File.read(path)
+
+      raw(locale_pack_content)
+    end
+
     def locale_pack_path(name, locale: nil)
       pack = LocalePack::Pack.find_by_name(name, locale: locale)
       pack.path


### PR DESCRIPTION
At this point the client apps using this library are injecting a `<script type='text/javascript' src='' />` tag in the webpage which then downloads the locale pack. This has an impact on the initial page load.

With this new helper, clients can choose to read the content of the locale file and serve the localePack preloaded on the window.