### PR TITLE
feat(setup): allow for custom locales

### DIFF
--- a/lib/locale_pack/railtie.rb
+++ b/lib/locale_pack/railtie.rb
@@ -18,7 +18,8 @@ module LocalePack
         config.config_path = app.config.locale_pack[:config_path] if app.config.locale_pack.key?(:config_path)
         config.locale_path = app.config.locale_pack[:locale_path] if app.config.locale_pack.key?(:locale_path)
         config.output_path = app.config.locale_pack[:output_path] if app.config.locale_pack.key?(:output_path)
-        config.export_locales = export_locales(app)
+        locales = export_locales(app)
+        config.export_locales = locales unless locales.nil?
       end
       # Include Helpers in ActionController and ActionView
       ActionController::Base.send :include, LocalePack::PackHelper

--- a/lib/locale_pack/railtie.rb
+++ b/lib/locale_pack/railtie.rb
@@ -62,7 +62,16 @@ module LocalePack
     private
 
     def export_locales(app)
-      app.config&.locale_pack&.locales || app.config&.i18n&.available_locales
+      fallback_locales = app.config&.i18n&.fallbacks
+      available_locales = app.config&.i18n&.available_locales
+
+      if fallback_locales.is_a?(Array)
+        available_locales.union(fallback_locales)
+      elsif fallback_locales.is_a?(Hash)
+        available_locales.union(fallback_locales.values.flatten)
+      else
+        available_locales if fallback_locales.nil?
+      end
     end
 
     def pack_listener

--- a/lib/locale_pack/railtie.rb
+++ b/lib/locale_pack/railtie.rb
@@ -18,7 +18,7 @@ module LocalePack
         config.config_path = app.config.locale_pack[:config_path] if app.config.locale_pack.key?(:config_path)
         config.locale_path = app.config.locale_pack[:locale_path] if app.config.locale_pack.key?(:locale_path)
         config.output_path = app.config.locale_pack[:output_path] if app.config.locale_pack.key?(:output_path)
-        config.export_locales = app.config.i18n.available_locales if app.config&.i18n&.available_locales
+        config.export_locales = export_locales(app)
       end
       # Include Helpers in ActionController and ActionView
       ActionController::Base.send :include, LocalePack::PackHelper
@@ -60,6 +60,10 @@ module LocalePack
     end
 
     private
+
+    def export_locales(app)
+      app.config&.locale_pack&.locales || app.config&.i18n&.available_locales
+    end
 
     def pack_listener
       Listen.to(LocalePack.config.config_path, only: /\.yml$/) do |modified, added, removed|


### PR DESCRIPTION
We need to support fallback locales as well.
Fallback locales can be either an array. Or a hash. We check the type and append them to the export locales.
In ruby-web we use a fallback like `{ en: :"en-US", se: :"se-SE", ... }` and the available_locales [:en, :se, ...] this should create a new array with `[:en, :se, :"en-US", :"se-SE"]`.