### PR TITLE
Add "locale_pack_json_content" helper

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,51 +6,60 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.1.5)
+    activesupport (7.1.3.4)
+      base64
+      bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (~> 0.7)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
-    codeclimate-test-reporter (1.0.8)
-      simplecov (<= 0.13)
-    concurrent-ruby (1.0.5)
-    diff-lcs (1.3)
-    docile (1.1.5)
-    factory_bot (4.8.2)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      mutex_m
+      tzinfo (~> 2.0)
+    base64 (0.2.0)
+    bigdecimal (3.1.8)
+    codeclimate-test-reporter (1.0.7)
+      simplecov
+    concurrent-ruby (1.3.3)
+    connection_pool (2.4.1)
+    diff-lcs (1.5.1)
+    docile (1.4.1)
+    drb (2.2.1)
+    factory_bot (4.11.1)
       activesupport (>= 3.0.0)
-    i18n (0.9.5)
+    i18n (1.14.5)
       concurrent-ruby (~> 1.0)
-    json (2.1.0)
-    minitest (5.11.3)
+    minitest (5.24.1)
+    mutex_m (0.2.0)
     rake (10.5.0)
-    rspec (3.7.0)
-      rspec-core (~> 3.7.0)
-      rspec-expectations (~> 3.7.0)
-      rspec-mocks (~> 3.7.0)
-    rspec-core (3.7.1)
-      rspec-support (~> 3.7.0)
-    rspec-expectations (3.7.0)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.0)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-mocks (3.7.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-support (3.7.1)
-    simplecov (0.13.0)
-      docile (~> 1.1.0)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
-    simplecov-rcov (0.2.3)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.1)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov-rcov (0.3.7)
       simplecov (>= 0.4.1)
-    thread_safe (0.3.6)
-    tzinfo (1.2.5)
-      thread_safe (~> 0.1)
-    yard (0.9.12)
+    simplecov_json_formatter (0.1.4)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    yard (0.9.36)
 
 PLATFORMS
   ruby
-  x64-mingw32
+  x86_64-linux
 
 DEPENDENCIES
   codeclimate-test-reporter
@@ -63,4 +72,4 @@ DEPENDENCIES
   yard (>= 0.9.11)
 
 BUNDLED WITH
-   1.17.1
+   2.5.15

--- a/lib/locale_pack/helpers/pack_helper.rb
+++ b/lib/locale_pack/helpers/pack_helper.rb
@@ -5,14 +5,18 @@ module LocalePack
 
     def javascript_locale_pack_tag(name, locale: nil)
       <<-EOS.html_safe
-      <script type='text/javascript' src='#{locale_pack_path(name, locale: locale)}'></script>
+      <script type='text/javascript' src='#{locale_pack_path(name, locale: locale, extension: 'js')}'></script>
       EOS
     end
 
-    def locale_pack_path(name, locale: nil)
+    def locale_pack_path(name, locale: nil, extension: 'js')
       pack = LocalePack::Pack.find_by_name(name, locale: locale)
-      pack.path
+      pack.path(extension: extension)
     end
 
+    def locale_pack_json_content(name, locale: nil)
+      pack = LocalePack::Pack.find_by_name(name, locale: locale)
+      pack.json_content
+    end
   end
 end

--- a/lib/locale_pack/models/manifest.rb
+++ b/lib/locale_pack/models/manifest.rb
@@ -27,6 +27,7 @@ module LocalePack
     def load!
       manifest_file = find_directory_manifest(LocalePack.config.output_path)
       return unless File.exist?(manifest_file)
+
       @packs = JSON.parse(File.read(manifest_file), symbolize_names: true)
     end
 

--- a/lib/locale_pack/models/pack.rb
+++ b/lib/locale_pack/models/pack.rb
@@ -20,11 +20,22 @@ module LocalePack
       @name      = options[:name]
       @digest    = options[:digest]
       @locale    = options[:locale]
-      @file_name = "#{@id}-#{options[:digest]}.js"
+      @file_name = "#{@id}-#{options[:digest]}"
     end
 
-    def path
-      "/locale_packs/#{self.file_name}"
+    def path(extension: 'js')
+      return ArgumentError, "invalid locale pack file extension" unless %w(js json).include?(extension)
+
+      "/locale_packs/#{self.file_name}.#{extension}"
+    end
+
+    def json_content
+      return @content if defined?(@content) && @content
+
+      json_path = File.join(LocalePack.config.output_path, "#{self.file_name}.json")
+      return '' unless File.exist?(json_path)
+
+      @content = File.read(json_path)
     end
 
     def ==(another_pack)

--- a/lib/locale_pack/models/pack_file.rb
+++ b/lib/locale_pack/models/pack_file.rb
@@ -54,12 +54,18 @@ module LocalePack
 
     def save
       LocalePack.config.export_locales.each do |locale|
-        File.open(compiled_file_path(locale: locale), 'w') do |f|
+        File.open(compiled_file_path(locale: locale, extension: 'js'), 'w') do |f|
           f.write("var localePack = #{data_for_locale(locale)};")
         end
+        File.open(compiled_file_path(locale: locale, extension: 'json'), 'w') do |f|
+          f.write(data_for_locale(locale))
+        end
       end
-      File.open(compiled_file_path, 'w') do |f|
+      File.open(compiled_file_path(extension: 'js'), 'w') do |f|
         f.write("var localePack = #{data};")
+      end
+      File.open(compiled_file_path(extension: 'json'), 'w') do |f|
+        f.write(data)
       end
     end
 
@@ -81,10 +87,10 @@ module LocalePack
       end.flatten
     end
 
-    def compiled_file_path(locale: nil)
+    def compiled_file_path(locale: nil, extension: 'js')
       file_name = (locale ?
-                       "#{self.name}_#{locale}-#{self.digest}.js" :
-                       "#{self.name}-#{self.digest}.js")
+                       "#{self.name}_#{locale}-#{self.digest}.#{extension}" :
+                       "#{self.name}-#{self.digest}.#{extension}")
       File.join(LocalePack.config.output_path, file_name)
     end
 


### PR DESCRIPTION
This adds a `locale_pack_json_content` helper that makes it easy to render the locale pack on f.ex. HTML data-attributes to avoid loading the pack as a separate js-resource. 

It is achieved by adding compilation of `.json` locale packs (in addition to the `.js` packs).